### PR TITLE
chore(docs): avoid master wording at setup cluster

### DIFF
--- a/src/docs/src/setup/cluster.rst
+++ b/src/docs/src/setup/cluster.rst
@@ -303,7 +303,7 @@ After that we can join all the nodes together. Choose one node as the "setup
 coordination node" to run all these commands on.  This "setup coordination
 node" only manages the setup and requires all other nodes to be able to see it
 and vice versa. *It has no special purpose beyond the setup process; CouchDB
-does not have the concept of a "master" node in a cluster.*
+does not have the concept of a primary node in a cluster.*
 
 Setup will not work with unavailable nodes. All nodes must be online and properly
 preconfigured before the cluster setup process can begin.


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Please file this form by replacing the Markdown comments
     with your text. If a section needs no action - remove it.

     Also remember, that CouchDB uses the Review-Then-Commit (RTC) model
     of code collaboration. Positive feedback is represented +1 from committers
     and negative is a -1. The -1 also means veto, and needs to be addressed
     to proceed. Once there are no objections, the PR can be merged by a
     CouchDB committer.

     See: http://couchdb.apache.org/bylaws.html#decisions for more info. -->

## Overview

<!-- Please give a short brief for the pull request,
     what problem it solves or how it makes things better. -->
Just a tiny wording change at setup cluster docs: changes "master" node to primary node.

## Testing recommendations

<!-- Describe how we can test your changes.
     Does it provide any behaviour that the end users
     could notice? -->

## Related Issues or Pull Requests

<!-- If your changes affect multiple components in different
     repositories please put links to those issues or pull requests here.  -->

## Checklist

- [ ] Code is written and works correctly
- [ ] Changes are covered by tests
- [ ] Any new configurable parameters are documented in `rel/overlay/etc/default.ini`
- [x] Documentation changes were made in the `src/docs` folder
- [x] Documentation changes were backported (separated PR) to affected branches
